### PR TITLE
Add X-OCL-CLIENT header for analytics tracking

### DIFF
--- a/src/services/APIService.js
+++ b/src/services/APIService.js
@@ -120,6 +120,7 @@ class APIService {
     const obj = defaults(headers, this.headers);
     if (token) obj['Authorization'] = `Token ${token}`;
     obj['INCLUDESEARCHLATEST'] = true
+    obj['X-OCL-CLIENT'] = 'oclweb3/3.0.0-alpha';
     return obj;
   }
 


### PR DESCRIPTION
## Summary
- Adds `X-OCL-CLIENT: oclweb3/3.0.0-alpha` header to all outgoing API requests
- Enables OCL Analytics to reliably identify traffic from this client instead of relying on imprecise User-Agent/Origin fallback detection

## Test plan
- [ ] Open browser dev tools → Network tab → verify `X-OCL-CLIENT` header on API requests
- [ ] Confirm analytics events show `client: oclweb3/3.0.0-alpha`

Refs OpenConceptLab/ocl_issues#2429

🤖 Generated with [Claude Code](https://claude.com/claude-code)