### PR TITLE
OpenConceptLab/ocl_issues#2574 | Polish collection reference displays

### DIFF
--- a/src/components/references/ReferenceSourceGroupedResults.jsx
+++ b/src/components/references/ReferenceSourceGroupedResults.jsx
@@ -17,29 +17,56 @@ import TableCell from '@mui/material/TableCell'
 import TableContainer from '@mui/material/TableContainer'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import CollapseIcon from '@mui/icons-material/KeyboardArrowDown'
 import ExpandIcon from '@mui/icons-material/KeyboardArrowRight'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import { SOURCE_COLORS } from '../../common/colors'
 import { hashString, URIToParentParams } from '../../common/utils'
+import ConceptIcon from '../concepts/ConceptIcon'
+import MappingIcon from '../mappings/MappingIcon'
 import RepoChip from '../repos/RepoChip'
 
 const getReferenceId = reference => reference.version_url || reference.url || reference.id
 
-const getReferenceSummary = reference => {
-  let label = ''
+const ReferenceResultCount = ({ count, icon, label }) => (
+  isNumber(count) && count > 0 ?
+    <Tooltip title={`${count.toLocaleString()} ${label}`}>
+      <Box component='span' sx={{display: 'inline-flex', alignItems: 'center', gap: 0.5, mr: 1}}>
+        {icon}
+        <Typography component='span' sx={{fontSize: '13px'}}>
+          {count.toLocaleString()}
+        </Typography>
+      </Box>
+    </Tooltip> :
+    null
+)
+
+const ReferenceResultsCell = ({ reference, t }) => {
   if(reference.last_resolved_at && reference.concepts === 0 && reference.mappings === 0)
     return '-'
-  if(isNumber(reference.concepts) && reference.concepts > 0)
-    label += `${reference.concepts.toLocaleString()} concepts`
-  if(isNumber(reference.mappings) && reference.mappings > 0) {
-    if(label?.length)
-      label += ', '
-    label += `${reference.mappings.toLocaleString()} mappings`
-  }
 
-  return label || '-'
+  const hasConcepts = isNumber(reference.concepts) && reference.concepts > 0
+  const hasMappings = isNumber(reference.mappings) && reference.mappings > 0
+
+  if(!hasConcepts && !hasMappings)
+    return '-'
+
+  return (
+    <Box sx={{display: 'flex', alignItems: 'center', flexWrap: 'wrap', rowGap: 0.5}}>
+      <ReferenceResultCount
+        count={reference.concepts}
+        icon={<ConceptIcon selected color='secondary' sx={{width: '9px', height: '9px'}} />}
+        label={t(reference.concepts === 1 ? 'concept.concept' : 'concept.concepts').toLowerCase()}
+      />
+      <ReferenceResultCount
+        count={reference.mappings}
+        icon={<MappingIcon color='secondary' sx={{width: '15px', height: '13px'}} />}
+        label={t(reference.mappings === 1 ? 'mapping.mapping' : 'mapping.mappings').toLowerCase()}
+      />
+    </Box>
+  )
 }
 
 const getSourceColorKey = source => [source?.owner, source?.id || source?.short_code].filter(Boolean).join('/')
@@ -144,17 +171,17 @@ const SourceGroup = ({ group, selected, onSelectedChange, onReferenceClick, isIt
     <React.Fragment>
       <TableRow sx={{backgroundColor: '#f8f7ff'}}>
         <TableCell padding='checkbox'>
+          <IconButton size='small' onClick={() => setExpanded(!expanded)}>
+            {expanded ? <CollapseIcon fontSize='small' /> : <ExpandIcon fontSize='small' />}
+          </IconButton>
+        </TableCell>
+        <TableCell padding='checkbox'>
           <Checkbox
             size={size || 'medium'}
             checked={allSelected}
             indeterminate={!allSelected && someSelected}
             onChange={onGroupSelect}
           />
-        </TableCell>
-        <TableCell padding='checkbox'>
-          <IconButton size='small' onClick={() => setExpanded(!expanded)}>
-            {expanded ? <CollapseIcon fontSize='small' /> : <ExpandIcon fontSize='small' />}
-          </IconButton>
         </TableCell>
         <TableCell colSpan={3}>
           <Box sx={{display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap'}}>
@@ -199,10 +226,10 @@ const SourceGroup = ({ group, selected, onSelectedChange, onReferenceClick, isIt
                 },
               }}
             >
+              <TableCell padding='checkbox' />
               <TableCell padding='checkbox' onClick={event => onRowSelect(event, id)}>
                 <Checkbox size={size || 'medium'} checked={isSelected} />
               </TableCell>
-              <TableCell padding='checkbox' />
               <TableCell className='searchable' sx={{pl: 3}}>
                 <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
                   {
@@ -212,7 +239,7 @@ const SourceGroup = ({ group, selected, onSelectedChange, onReferenceClick, isIt
                   <Typography sx={{fontSize: '13px'}}>{getConceptLabel(reference)}</Typography>
                 </Box>
               </TableCell>
-              <TableCell>{reference.last_resolved_at ? getReferenceSummary(reference) : '-'}</TableCell>
+              <TableCell>{reference.last_resolved_at ? <ReferenceResultsCell reference={reference} t={t} /> : '-'}</TableCell>
               <TableCell align='right'>
                 <IconButton size='small' onClick={event => onReferenceClick(event, id)}>
                   <MoreVertIcon fontSize='small' />

--- a/src/components/repos/CollectionVersionsTab.jsx
+++ b/src/components/repos/CollectionVersionsTab.jsx
@@ -168,6 +168,38 @@ const bodyCellSx = {
   py: 1.25
 };
 
+const countHeaderCellSx = {
+  ...headerCellSx,
+  width: "16%"
+};
+
+const countBodyCellSx = {
+  ...bodyCellSx,
+  width: "16%"
+};
+
+const actionHeaderCellSx = {
+  ...headerCellSx,
+  width: "1%",
+  whiteSpace: "nowrap"
+};
+
+const resolvedHeaderCellSx = {
+  ...headerCellSx,
+  width: "16%"
+};
+
+const actionBodyCellSx = {
+  ...bodyCellSx,
+  width: "1%",
+  whiteSpace: "nowrap"
+};
+
+const resolvedBodyCellSx = {
+  ...bodyCellSx,
+  width: "16%"
+};
+
 const compactButtonSx = {
   minWidth: 0,
   px: 0,
@@ -697,20 +729,20 @@ const CollectionVersionsTab = ({
               </Box>
             </Box>
           </TableCell>
-          <TableCell sx={{ ...bodyCellSx, width: "16%" }}>
+          <TableCell sx={countBodyCellSx}>
             <CountCell value={get(version, "summary.active_concepts")} />
           </TableCell>
-          <TableCell sx={{ ...bodyCellSx, width: "16%" }}>
+          <TableCell sx={countBodyCellSx}>
             <CountCell value={get(version, "summary.active_mappings")} />
           </TableCell>
-          <TableCell sx={{ ...bodyCellSx, width: "16%" }}>
+          <TableCell sx={countBodyCellSx}>
             {versionLoading ? (
               <CircularProgress size={18} />
             ) : (
               <CountCell value={getReferencesCount(version)} />
             )}
           </TableCell>
-          <TableCell sx={{ ...bodyCellSx, width: "1%", whiteSpace: "nowrap" }}>
+          <TableCell sx={actionBodyCellSx}>
             {hasAccess && (
               <IconButton
                 size="small"
@@ -731,23 +763,23 @@ const CollectionVersionsTab = ({
             }}
           >
             <Collapse in={expanded} timeout="auto" unmountOnExit>
-              <Box sx={{ px: 2, py: 1 }}>
+              <Box sx={{ px: 0, py: 1 }}>
                 <Table size="small">
                   <TableHead>
                     <TableRow>
                       <TableCell sx={headerCellSx}>
                         {t("repo.expansions")}
                       </TableCell>
-                      <TableCell sx={headerCellSx}>
+                      <TableCell sx={countHeaderCellSx}>
                         {t("search.concepts")}
                       </TableCell>
-                      <TableCell sx={headerCellSx}>
+                      <TableCell sx={countHeaderCellSx}>
                         {t("search.mappings")}
                       </TableCell>
-                      <TableCell sx={headerCellSx}>
+                      <TableCell sx={resolvedHeaderCellSx}>
                         {t("repo.resolved_repo_versions")}
                       </TableCell>
-                      <TableCell sx={headerCellSx} />
+                      <TableCell sx={actionHeaderCellSx} />
                     </TableRow>
                   </TableHead>
                   <TableBody>
@@ -911,13 +943,13 @@ const CollectionVersionsTab = ({
                                 )}
                               </Box>
                             </TableCell>
-                            <TableCell sx={bodyCellSx}>
+                            <TableCell sx={countBodyCellSx}>
                               <CountCell value={get(expansion, "summary.active_concepts")} />
                             </TableCell>
-                            <TableCell sx={bodyCellSx}>
+                            <TableCell sx={countBodyCellSx}>
                               <CountCell value={get(expansion, "summary.active_mappings")} />
                             </TableCell>
-                            <TableCell sx={bodyCellSx}>
+                            <TableCell sx={resolvedBodyCellSx}>
                               <Box sx={{ minWidth: 0 }}>
                                 <Typography
                                   sx={{
@@ -1005,13 +1037,7 @@ const CollectionVersionsTab = ({
                                 )}
                               </Box>
                             </TableCell>
-                            <TableCell
-                              sx={{
-                                ...bodyCellSx,
-                                width: "1%",
-                                whiteSpace: "nowrap"
-                              }}
-                            >
+                            <TableCell sx={actionBodyCellSx}>
                               {hasAccess && (
                                 <IconButton
                                   size="small"


### PR DESCRIPTION
## Linked Issue

Closes OpenConceptLab/ocl_issues#2574

## Summary

- Moves the source-group expand/collapse control to the left of the checkbox column so grouped references read as a hierarchy instead of a flat list.
- Updates the references Results column to use the same concept/mapping icon + count pattern used elsewhere in the UI.
- Aligns the Versions + Expansions concept/mapping count columns by sharing the same count/action column widths between version rows and expansion rows.

## Test Plan

- [x] `npm ci --ignore-scripts`
- [x] `./node_modules/.bin/eslint src/components/references/ReferenceSourceGroupedResults.jsx src/components/repos/CollectionVersionsTab.jsx`
- [ ] `NODE_ENV=production npm run build` — attempted, but the local build is blocked by the existing `node-sass@4.14.1` runtime incompatibility on macOS arm64 / Node v25 (`Unsupported runtime (141)`). Webpack reached compilation and failed in Sass loader for existing SCSS/CSS imports, not in the touched JSX files.

## Notes

I kept this PR scoped to the three display polish items in `#2574`; it does not change reference data fetching or expansion behavior.
