### PR TITLE
fix: allow Concept Compare screen to scroll when content overflows

### DIFF
--- a/src/components/app/App.scss
+++ b/src/components/app/App.scss
@@ -2,8 +2,7 @@ main.content {
     display: inline-block;
     width: 100%;
     height: calc(100vh - 95px);
-    overflow-x: hidden;
-    overflow-y: auto;
+    overflow: hidden;
 }
 div.rounded-input {
     border-radius: 100px;

--- a/src/components/app/App.scss
+++ b/src/components/app/App.scss
@@ -2,7 +2,8 @@ main.content {
     display: inline-block;
     width: 100%;
     height: calc(100vh - 95px);
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 div.rounded-input {
     border-radius: 100px;

--- a/src/components/common/Comparison.jsx
+++ b/src/components/common/Comparison.jsx
@@ -302,7 +302,7 @@ class Comparison extends React.Component {
             <CircularProgress color='primary' />
           </div> :
           <div className='col-md-12' style={{paddingTop: '10px', paddingBottom: '10px'}}>
-            <TableContainer  style={{borderRadius: '4px', border: '1px solid lightgray'}}>
+          <TableContainer  style={{borderRadius: '4px', border: '1px solid lightgray', maxHeight: 'calc(100vh - 110px)'}}>
               <Table size='small'>
                 <TableHead>
                   <TableRow colSpan="12">


### PR DESCRIPTION
## Summary
- `main.content` in `App.scss` had `overflow: hidden`, clipping all page content below the viewport fold
- Changed to `overflow-x: hidden; overflow-y: auto` so the container scrolls vertically when content overflows
- Pages with their own inner scroll containers (e.g. Concept Details, Reference Details) are unaffected — their inner divs use `height: calc(100vh - X)` where X > 95, so they fit within `main.content` and don't trigger an outer scrollbar

Fixes https://github.com/OpenConceptLab/ocl_issues/issues/2595

## Test plan
- [ ] Open Concept Compare with a concept that has many mappings: https://app.v3.openconceptlab.org/#/concepts/compare?lhs=/orgs/CIEL/sources/CIEL/v2026-05-30/concepts/1208/&rhs=/orgs/CIEL/sources/CIEL/v2026-06-27/concepts/1208/
- [ ] Expand the Mappings section and confirm you can scroll down to see all 46 rows
- [ ] Verify Concept Detail page still scrolls correctly within its own inner container (no double scrollbar)
- [ ] Verify Mapping Compare page works the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)