### PR TITLE
build(config): standardize service port definitions in docker-compose…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
 node_modules/
 src/stories/
 .storybook/
-dist/
 .idea/
+dist/
+.env
 .DS_Store
 CLAUDE.md
+
+# Local Docker Compose overrides
+docker-compose.override.yml
+
 # Added by code-review-graph
 .code-review-graph/
 .claude/

--- a/README.md
+++ b/README.md
@@ -2,16 +2,22 @@
 OCL TermBrowser v3 user interface for terminology management using an OCL Terminology Server
 
 ### Run Dev
-1. docker-compose up -d
-2. Visit http://localhost:4002
+1. Create your local Compose override: `cp docker-compose.override.yml.bak docker-compose.override.yml`
+2. Adjust `docker-compose.override.yml` if you need local build, volume, or port settings.
+3. Run `docker compose up -d`
+4. Visit the port configured by `WEB_PORT`, or `http://localhost:4002` by default.
+
+`docker-compose.override.yml` is intentionally not versioned because each development environment may need different settings. To change the host port without editing the override, run `WEB_PORT=4012 docker compose up -d`, for example.
 
 ### Run Dev with KeyCloak (SSO)
-1. docker-compose -f docker-compose.yml -f docker-compose.sso.yml up -d
-2. Visit http://localhost:4002
+1. Run `docker compose -f docker-compose.yml -f docker-compose.sso.yml up -d`.
+2. Visit the port configured by `WEB_PORT`, or `http://localhost:4002` by default.
+
+The SSO redirect follows `WEB_PORT`. You can still set `LOGIN_REDIRECT_URL` explicitly when a different callback URL is required. For example: `WEB_PORT=4012 docker compose -f docker-compose.yml -f docker-compose.sso.yml up -d`.
 
 ### Run Production (do check CORS origin policy with API_URL)
-1. docker-compose -f docker-compose.yml up -d
-2. Visit http://localhost:4002
+1. Run `docker compose -f docker-compose.yml up -d`.
+2. Visit the port configured by `WEB_PORT`, or `http://localhost:4002` by default.
 
 
 ### Eslint

--- a/docker-compose.override.yml.bak
+++ b/docker-compose.override.yml.bak
@@ -1,8 +1,6 @@
-version: '3'
-
 services:
   web:
-    image: openconceptlab/oclweb3:${TAG-dev}
+    image: openconceptlab/oclweb3:${TAG:-dev}
     build:
       context: .
       target: build
@@ -10,9 +8,9 @@ services:
         NODE_ENV: development
         PRIVATE_PACKAGES_GIT:
     ports:
-      - "4002:4002"
-      - "4003:35729"
-      - "6007:6006"
+      - "${WEB_PORT:-4002}:4002"
+      - "${LIVE_RELOAD_PORT:-4003}:35729"
+      - "${STORYBOOK_PORT:-6007}:6006"
     restart: on-failure
     volumes:
       - .:/app:z

--- a/docker-compose.sso.yml
+++ b/docker-compose.sso.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     image: openconceptlab/oclweb3:${TAG-dev}
@@ -10,13 +8,13 @@ services:
         NODE_ENV: development
         PRIVATE_PACKAGES_GIT:
     ports:
-      - "4002:4002"
-      - "4003:35729"
-      - "6007:6006"
+      - "${WEB_PORT:-4002}:4002"
+      - "${LIVE_RELOAD_PORT:-4003}:35729"
+      - "${STORYBOOK_PORT:-6007}:6006"
     restart: on-failure
     volumes:
       - .:/app:z
     environment:
-      - LOGIN_REDIRECT_URL=${LOGIN_REDIRECT_URL-http://localhost:4002}
+      - LOGIN_REDIRECT_URL=${LOGIN_REDIRECT_URL:-http://localhost:${WEB_PORT:-4002}}
       - OIDC_RP_CLIENT_ID=${OIDC_RP_CLIENT_ID-ocllocal}
       - OIDC_RP_CLIENT_SECRET

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     image: openconceptlab/oclweb3:${TAG-latest}
@@ -9,7 +7,7 @@ services:
         NODE_ENV: production
         PRIVATE_PACKAGES_GIT:
     ports:
-      - "4002:4002"
+      - "${WEB_PORT:-4002}:4002"
     restart: on-failure
     environment:
       - API_URL=${API_URL-http://127.0.0.1:8000}


### PR DESCRIPTION
* Update all services to use environment variables for dynamic port mapping instead of static values

* Revise README documentation to provide clearer instructions on running the development environment and using compose overrides

Address https://github.com/OpenConceptLab/oclweb3/pull/33