### PR TITLE
Security | Strip auth params from hash before GA pageview

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -587,7 +587,8 @@ export const getOpenMRSURL = () => {
 export const recordGAPageView = () => {
   /*eslint no-undef: 0*/
   ReactGA.initialize(window.GA_ACCOUNT_ID || process.env.GA_ACCOUNT_ID);
-  ReactGA.send({ hitType: "pageview", page: window.location.pathname + window.location.hash });
+  // Strip the query string from the hash so auth params (code, state, session_state) on the OIDC callback are not sent to GA
+  ReactGA.send({ hitType: "pageview", page: window.location.pathname + window.location.hash.split('?')[0] });
 }
 
 export const recordGAAction = (category, action, label) => {


### PR DESCRIPTION
Follow-up to OpenConceptLab/ocl_online#131 (hardening). Closes the analytics half.

## Problem
`recordGAPageView()` sends `window.location.pathname + window.location.hash` to Google Analytics. On the OIDC callback the hash is `/#/oidc/login/?state=…&code=…&session_state=…`, so the auth **code** and **session_state** are transmitted to GA.

(The server access-log concern does **not** apply — the promotion script in `public/index.html` keeps auth params in the URL fragment, which never reaches the server. GA is the only leak.)

## Fix
Strip the query string from the hash before sending to GA (`src/common/utils.js`, `recordGAPageView`). Route path is preserved; also stops search terms and other hash query params from leaking into GA pageview URLs.

Ref OpenConceptLab/ocl_online#138. Sibling PRs in oclmap and oclweb2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)